### PR TITLE
Add "files" key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.1",
   "description": "a javascript xpreadsheet",
   "main": "src/index.js",
+  "files": [
+    "assets",
+    "src"
+  ],
   "author": "myliang <liangyuliang0335@gmail.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This adds the `files` key so that only the files in `assets` and `src` directories are published to npm.

See [the docs](https://docs.npmjs.com/files/package.json#files) for more info.