### PR TITLE
make contributions easier

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+ports:
+- port: 8080
+  onOpen: open-preview
+tasks:
+- init: npm install
+  command: npm run dev

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@
 ## Install
 ``` shell
 npm install x-data-spreadsheet
-``` 
+```
 
 ## Quick Start
 ``` html
@@ -33,6 +33,12 @@ npm install
 npm run dev
 ```
 Open your browser and visit http://127.0.0.1:8080.
+
+<hr>
+
+You can also build & run x-spreadsheet in a free online workspace using Gitpod:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/myliang/x-spreadsheet)
 
 ## Browser Support
 Modern browsers(chrome, firefox, Safari).

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -27,5 +27,6 @@ module.exports = merge(common, {
   devServer: {
     host: '0.0.0.0',
     contentBase: './dist',
+    disableHostCheck: true,
   },
 });


### PR DESCRIPTION
Hello, thanks a lot for making x-spreadsheet!

I work on Gitpod, a service that provides free workspaces in the cloud, and I wanted to make it easier to contribute to this project. So I've configured Gitpod to automatically run `npm install` and `npm run dev` on start-up, and to automatically open the dev server in a web preview.

Here is what it looks like:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/c7d26c93-5d46-470b-afe5-178deff83495)
<img width="1552" alt="screenshot 2019-01-29 at 14 39 42" src="https://user-images.githubusercontent.com/599268/51913661-54410980-23d7-11e9-8792-6fc9c000059c.png">

Note: To make it work, I've had to make a small change to the `webpack.dev.js` config: disabling the host check (otherwise, the web preview just shows `Invalid Host Header`).