### PR TITLE
Fixes for Scrolling using touch pad and fixes for non-editable cells

### DIFF
--- a/src/component/sheet.js
+++ b/src/component/sheet.js
@@ -775,8 +775,20 @@ function sheetInitEvents() {
         || (keyCode >= 96 && keyCode <= 105)
         || evt.key === '='
       ) {
-        dataSetCellText.call(this, evt.key, 'input');
-        editorSet.call(this);
+        //Pass the input event handle if only the cell is editable
+        const range = this.selector.range;
+        const cell = this.data.getCell(range['sri'],range['sci']);
+        if(cell !== null){
+          if(("editable" in cell && cell.editable == true) || (cell['editable'] === undefined)) {
+            dataSetCellText.call(this, evt.key, 'input');
+            editorSet.call(this);
+          }
+        }
+        //Pass the input event handle when the cell is empty
+        else{
+          dataSetCellText.call(this, evt.key, 'input');
+          editorSet.call(this);
+        }
       } else if (keyCode === 113) {
         // F2
         editorSet.call(this);

--- a/src/component/sheet.js
+++ b/src/component/sheet.js
@@ -140,38 +140,41 @@ function overlayerMousescroll(evt) {
   const { rows, cols } = data;
 
   // deltaY for vertical delta
-  let { deltaY } = evt;
+  let { deltaY,deltaX  } = evt;
   // console.log('deltaX', deltaX, 'evt.detail', evt.detail);
   if (evt.detail) deltaY = evt.detail * 40;
-  if (deltaY > 0) {
-    // up
-    const ri = data.scroll.ri + 1;
-    if (ri < rows.len) {
-      verticalScrollbar.move({ top: top + rows.getHeight(ri) - 1 });
-    }
-  } else {
-    // down
-    const ri = data.scroll.ri - 1;
-    if (ri >= 0) {
-      verticalScrollbar.move({ top: ri === 0 ? 0 : top - rows.getHeight(ri) });
+  if(Math.abs(deltaY)>Math.abs(deltaX) && Math.abs(deltaX)==0 ){
+    if (deltaY > 0) {
+      // up
+      const ri = data.scroll.ri + 1;
+      if (ri < rows.len) {
+        verticalScrollbar.move({ top: top + rows.getHeight(ri) - 1 });
+      }
+    } else {
+      // down
+      const ri = data.scroll.ri - 1;
+      if (ri >= 0) {
+        verticalScrollbar.move({ top: ri === 0 ? 0 : top - rows.getHeight(ri) });
+      }
     }
   }
-
+  
   // deltaX for Mac horizontal scroll
-  const { deltaX } = evt;
-  if (deltaX > 0) {
-    // left
-    const ci = data.scroll.ci + 1;
-    if (ci < cols.len) {
-      horizontalScrollbar.move({ left: left + cols.getWidth(ci) - 1 });
-    }
-  } else {
-    // right
-    const ci = data.scroll.ci - 1;
-    if (ci >= 0) {
-      horizontalScrollbar.move({
-        left: ci === 0 ? 0 : left - cols.getWidth(ci),
-      });
+  if(Math.abs(deltaX)>Math.abs(deltaY) && Math.abs(deltaY)==0){
+    if (deltaX > 0) {
+      // left
+      const ci = data.scroll.ci + 1;
+      if (ci < cols.len) {
+        horizontalScrollbar.move({ left: left + cols.getWidth(ci) - 1 });
+      }
+    } else {
+      // right
+      const ci = data.scroll.ci - 1;
+      if (ci >= 0) {
+        horizontalScrollbar.move({
+          left: ci === 0 ? 0 : left - cols.getWidth(ci),
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes for scrolling wherein when using touch pad that leads to shaking of the sheet in both horizontal and vertical direction.

Fixes for not allowing the editing of cells without double clicking when the cell editing is disabled.