### PR TITLE
Fix outline-width: 0 being ignored in safari

### DIFF
--- a/src/index.less
+++ b/src/index.less
@@ -362,7 +362,7 @@ body {
       box-sizing: content-box;
       border: none;
       padding: 0 3px;
-      outline-width: 0;
+      outline: none;
       resize: none;
       text-align: start;
       overflow-y: hidden;
@@ -646,7 +646,7 @@ body {
 .@{css-prefix}-canvas-card {
   background: #fff;
   margin: auto;
-  page-break-before: auto;        
+  page-break-before: auto;
   page-break-after: always;
   box-shadow: 0 8px 10px 1px rgba(0,0,0,0.14), 0 3px 14px 3px rgba(0,0,0,0.12), 0 4px 5px 0 rgba(0,0,0,0.20);
 }


### PR DESCRIPTION
### before
![a1](https://user-images.githubusercontent.com/6650440/74840677-5b301680-5362-11ea-8764-9ea7f342a748.png)

### after
![a2](https://user-images.githubusercontent.com/6650440/74840700-65eaab80-5362-11ea-8254-81fe9042a475.png)