### PR TITLE
修复中文输入首字母被截取的问题

### DIFF
--- a/src/component/editor.js
+++ b/src/component/editor.js
@@ -108,7 +108,6 @@ function inputEventHandler(evt) {
 function setTextareaRange(position) {
   const { el } = this.textEl;
   setTimeout(() => {
-    el.focus();
     el.setSelectionRange(position, position);
   }, 0);
 }
@@ -198,6 +197,11 @@ export default class Editor {
   setFreezeLengths(width, height) {
     this.freeze.w = width;
     this.freeze.h = height;
+  }
+
+  focus(){
+    const { textEl } = this;
+    textEl.focus();
   }
 
   clear() {

--- a/src/component/sheet.js
+++ b/src/component/sheet.js
@@ -66,6 +66,7 @@ function selectorSet(multiple, ri, ci, indexesUpdated = true, moving = false) {
   if (ri === -1 && ci === -1) return;
   const {
     table, selector, toolbar, data,
+    editor,
     contextMenu,
   } = this;
   contextMenu.setMode((ri === -1 || ci === -1) ? 'row-col' : 'range');
@@ -80,6 +81,7 @@ function selectorSet(multiple, ri, ci, indexesUpdated = true, moving = false) {
   }
   toolbar.reset();
   table.render();
+  editor.focus();
 }
 
 // multiple: boolean


### PR DESCRIPTION
修复在windows系统中选中单元格情况下，直接使用中文输入法，会导致首字母被截取的问题。
原理：保证input框始终聚焦
测试环境：windows/chrome