### PR TITLE
[fix] the display value should be 100 times when using percentage format

### DIFF
--- a/src/core/format.js
+++ b/src/core/format.js
@@ -37,7 +37,7 @@ const baseFormats = [
     title: tf('format.percent'),
     type: 'number',
     label: '10.12%',
-    render: v => `${v}%`,
+    render: v => `${v * 100}%`,
   },
   {
     key: 'rmb',


### PR DESCRIPTION
Hi @myliang , I don't know which is the correct scenario. But in excel and google sheet, it's the second solution.
[before] 1.23 -> 1.23%
[after] 1.23 -> 123%