### PR TITLE
Added missing return types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,18 +45,18 @@ declare module 'x-data-spreadsheet' {
     (
       envt: CELL_SELECTED,
       callback: (cell: Cell, rowIndex: number, colIndex: number) => void
-    );
+    ): void;
     (
       envt: CELLS_SELECTED,
       callback: (
         cell: Cell,
         parameters: { sri: number; sci: number; eri: number; eci: number }
       ) => void
-    );
+    ): void;
     (
       evnt: CELL_EDITED,
       callback: (text: string, rowIndex: number, colIndex: number) => void
-    );
+    ): void;
   }
 
   export interface ColProperties {
@@ -180,13 +180,13 @@ declare module 'x-data-spreadsheet' {
      * bind handler to change event, including data change and user actions
      * @param callback
      */
-    change(callback: (json: Record<string, any>) => void);
+    change(callback: (json: Record<string, any>) => void): void;
     /**
      * set locale
      * @param lang
      * @param message
      */
-    locale(lang: string, message: string);
+    locale(lang: string, message: string): void;
   }
   global {
     interface Window {


### PR DESCRIPTION
Added return types on SpreadsheetEventHandler, Spreadsheet.change() and Spreadsheet.locale().

When compiling a TypeScript project with the option `--strict` or `--noImplicitAny` and x-data-spreadsheet as a dependency, the following TypeErrors occur :
```
ERROR in C:/Mes Documents/Polytech/GoodFlow/Code/front-end-web/node_modules/x-data-spreadsheet/src/index.d.ts(45,5):
45:5 Call signature, which lacks return-type annotation, implicitly has an 'any' return type.
ERROR in C:/Mes Documents/Polytech/GoodFlow/Code/front-end-web/node_modules/x-data-spreadsheet/src/index.d.ts(49,5):
49:5 Call signature, which lacks return-type annotation, implicitly has an 'any' return type.
ERROR in C:/Mes Documents/Polytech/GoodFlow/Code/front-end-web/node_modules/x-data-spreadsheet/src/index.d.ts(56,5):
56:5 Call signature, which lacks return-type annotation, implicitly has an 'any' return type.
ERROR in C:/Mes Documents/Polytech/GoodFlow/Code/front-end-web/node_modules/x-data-spreadsheet/src/index.d.ts(183,5):
183:5 'change', which lacks return-type annotation, implicitly has an 'any' return type.
ERROR in C:/Mes Documents/Polytech/GoodFlow/Code/front-end-web/node_modules/x-data-spreadsheet/src/index.d.ts(189,5):
189:5 'locale', which lacks return-type annotation, implicitly has an 'any' return type.
```

These errors no longer appear after adding the missing return types.

I set them to void as it is what was already done with other Spreadsheet methods even though they sometimes return `this` in their JavaScript implementations.