### PR TITLE
Make 'npm run test' command cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "webpack --config build/webpack.prod.js",
     "build-locale": "webpack --config build/webpack.locale.js",
     "lint": "./node_modules/eslint/bin/eslint.js src",
-    "test": "nyc ./node_modules/mocha/bin/mocha --require @babel/register test/*",
+    "test": "nyc ./node_modules/mocha/bin/mocha --require @babel/register --recursive test",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov -t 31ecdb12-8ecb-46f7-a486-65c2516307dd",
     "postinstall": "opencollective-postinstall"
   },


### PR DESCRIPTION
Fixes a path error on Windows when looking for tests within the test folder.