### PR TITLE
Improve locale flexibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "nyc": {
     "all": true,
     "include": [
-      "src/core/*.js"
+      "src/core/*.js",
+      "src/locale/locale.js"
     ],
     "exclude": [
       "**/*.spec.js"

--- a/src/locale/locale.js
+++ b/src/locale/locale.js
@@ -1,23 +1,36 @@
 /* global window */
 import en from './en';
 
-let $lang = 'en';
+// Defines the fallback language as English
+let $languages = ['en'];
 const $messages = {
   en,
 };
 
 function translate(key, messages) {
-  if (messages && messages[$lang]) {
-    let message = messages[$lang];
-    const keys = key.split('.');
-    for (let i = 0; i < keys.length; i += 1) {
-      const property = keys[i];
-      const value = message[property];
-      if (i === keys.length - 1) return value;
-      if (!value) return undefined;
-      message = value;
+  if (messages) {
+    // Return the translation from the first language in the languages array
+    // that has a value for the provided key.
+    for (const lang of $languages) {
+      if (!messages[lang]) break;
+
+      let message = messages[lang];
+      const keys = key.split('.');
+      for (let i = 0; i < keys.length; i += 1) {
+        const property = keys[i];
+        const value = message[property];
+
+        // If value doesn't exist, try next language
+        if (!value) break;
+
+        if (i === keys.length - 1) return value;
+
+        // Move down to the next level of the messages object
+        message = value;
+      }
     }
   }
+
   return undefined;
 }
 
@@ -33,8 +46,21 @@ function tf(key) {
   return () => t(key);
 }
 
-function locale(lang, message) {
-  $lang = lang;
+// If clearLangList is set to false, lang will be added to the front of the
+// languages array. The languages in the language array are searched in order
+// to find a translation. This allows the use of other languages as a fallback
+// if lang is missing some keys. The language array is preloaded with English.
+// To set the languages array to only include lang, set clearLangList to true.
+function locale(lang, message, clearLangList=false) {
+  if (clearLangList) {
+    $languages = [lang];
+  } else {
+    // Append to front of array.
+    // Translation method will use the first language in the list that has a
+    // matching key.
+    $languages.unshift(lang);
+  }
+
   if (message) {
     $messages[lang] = message;
   }

--- a/src/locale/locale.js
+++ b/src/locale/locale.js
@@ -15,7 +15,10 @@ function translate(key, messages) {
       if (!messages[lang]) break;
 
       let message = messages[lang];
-      const keys = key.split('.');
+
+      // Splits the key at '.' except where escaped as '\.'
+      const keys = key.match(/(?:\\.|[^.])+/g);
+
       for (let i = 0; i < keys.length; i += 1) {
         const property = keys[i];
         const value = message[property];

--- a/test/locale/locale_test.js
+++ b/test/locale/locale_test.js
@@ -1,0 +1,95 @@
+import assert from 'assert';
+import { describe, it } from 'mocha';
+import {
+  locale,
+  t,
+  tf
+} from '../../src/locale/locale';
+
+// Add window global if it doesn't exist
+// Some tests depend on this global variable's existence
+if (typeof window === 'undefined') {
+  global.window = {};
+}
+
+// Override messages that exist in the fallback locale
+const localeTest1 = 'TEST_1';
+const localeTest1Messages = {
+	toolbar: {
+		undo: 'Test 1 Undo',
+		redo: 'Test 1 Redo',
+	},
+	formula: {
+		"VAR\\.P": "Test 1 VARP"
+	}
+};
+
+const localeTest2 = 'TEST_2';
+const localeTest2Messages = {
+	toolbar: {
+		undo: 'Test 2 Undo',
+    // Do not define "redo" message in locale test 2
+	},
+};
+
+describe('locale', () => {
+  describe('.t()', () => {
+    it('should return an empty string when the value has no available translation', () => {
+      assert.equal(t('something.not.defined'), '');
+    });
+    it('should return Undo when the value is toolbar.undo', () => {
+      assert.equal(t('toolbar.undo'), 'Undo');
+    });
+  });
+  describe('.tf()', () => {
+    it('should return Undo when the value is toolbar.undo', () => {
+      const functionWhichReturnsTranslatedValue = tf('toolbar.undo');
+      assert.equal(functionWhichReturnsTranslatedValue(), 'Undo');
+    });
+  });
+  describe('.locale()', () => {
+  	// Must be the first test which calls the locale function,
+  	// as it depends on the first locale in the language list to be unchanged
+  	// from the default (English). Subsequent tests must clear the language
+  	// list to work as intended (otherwise thet language list will grow with
+  	// each test).
+    it('should return Print when the value is toolbar.print and the fallback locale is English', () => {
+      // Provides no value for toolbar.print, so the English fallback will be used
+      locale(localeTest1, localeTest1Messages, false);
+      assert.equal(t('toolbar.print'), 'Print');
+    });
+    it('should return Test 2 Undo when the value is toolbar.undo', () => {
+      // Set language list to prioritize use of locale test 2, then locale test 1
+      locale(localeTest1, localeTest1Messages, true);
+      locale(localeTest2, localeTest2Messages, false);
+
+      assert.equal(t('toolbar.undo'), 'Test 2 Undo');
+    });
+    it('should return Test 1 Redo when the value is toolbar.redo', () => {
+      // Set language list to prioritize use of locale test 2, then locale test 1
+      locale(localeTest1, localeTest1Messages, true);
+      locale(localeTest2, localeTest2Messages, false);
+
+      // locale test 2 doesn't have the toolbar.redo message defined
+      assert.equal(t('toolbar.redo'), 'Test 1 Redo');
+    });
+  });
+  describe('.t() [tests which depend on modified language list]', () => {
+    it('should return Test 1 VARP when the value is toolbar.formula.VAR\\.P', () => {
+      locale(localeTest1, localeTest1Messages, true);
+      assert.equal(t('formula.VAR\\.P'), 'Test 1 VARP');
+    });
+    it('should return Test 1 Redo when the value is toolbar.redo and a fallback is specified on the window global', () => {
+      // Only define locale test 2 messages here
+      locale(localeTest2, localeTest2Messages, true);
+
+      // Depends on existence of window global variable
+      // Supply a fallback locale test 2 message dictionary (from locale test 1)
+      window.x_spreadsheet = { $messages: {
+        'TEST_2': localeTest1Messages
+      }};
+
+      assert.equal(t('toolbar.redo'), 'Test 1 Redo');
+    });
+  });
+});


### PR DESCRIPTION
Includes the following improvements:
- Translation Fallback: If a translation is attempted but no associated key exists in the primary locale, the application can use fallback locale(s). The default fallback locale is English but this can be overridden when specifying a locale to use.
- Support Translation Keys Containing ".": requires use of an escape character (e.g., "VAR\\.P" to create a key for "VAR.P")
- Unit tests for locale.js