### PR TITLE
Prevent hijacking of paste on unrelated elements

### DIFF
--- a/src/component/sheet.js
+++ b/src/component/sheet.js
@@ -693,6 +693,7 @@ function sheetInitEvents() {
   });
 
   bind(window, 'paste', (evt) => {
+    if(!this.focusing) return;
     paste.call(this, 'all', evt);
     evt.preventDefault();
   });


### PR DESCRIPTION
This is useful when other elements are present on same page with spreadsheet (e.g. input fields)