### PR TITLE
Return raw string if cell value is not a number

### DIFF
--- a/src/core/cell.js
+++ b/src/core/cell.js
@@ -134,7 +134,9 @@ const evalSubExpr = (subExpr, cellRender) => {
     return ret * Number(expr);
   }
   const [x, y] = expr2xy(expr);
-  return ret * cellRender(x, y);
+  const rendered = cellRender(x, y);
+  const calculated = ret * rendered;
+  return isNaN(calculated) ? rendered : calculated;
 };
 
 // evaluate the suffix expression


### PR DESCRIPTION
I've updated `evalSubExpr` to check cell value is a number or not.

This causes returning `NaN` when `CONCAT` enating non number cell values like.

| A    |  B |
| ---  | ---  |
| bar | =CONCAT(A1:A3) |
| foo |  |
| 1 |  |

- Expected: `barfoo1`
- Actual: `NaN`