### PR TITLE
Add "features" to settings to enable/disable single features

### DIFF
--- a/src/component/contextmenu.js
+++ b/src/component/contextmenu.js
@@ -9,29 +9,29 @@ const menuItems = [
   { key: 'paste', title: tf('contextmenu.paste'), label: 'Ctrl+V' },
   { key: 'paste-value', title: tf('contextmenu.pasteValue'), label: 'Ctrl+Shift+V' },
   { key: 'paste-format', title: tf('contextmenu.pasteFormat'), label: 'Ctrl+Alt+V' },
-  { key: 'divider' },
-  { key: 'insert-row', title: tf('contextmenu.insertRow') },
-  { key: 'insert-column', title: tf('contextmenu.insertColumn') },
-  { key: 'divider' },
-  { key: 'delete-row', title: tf('contextmenu.deleteRow') },
-  { key: 'delete-column', title: tf('contextmenu.deleteColumn') },
-  { key: 'delete-cell-text', title: tf('contextmenu.deleteCellText') },
-  { key: 'hide', title: tf('contextmenu.hide') },
-  { key: 'divider' },
-  { key: 'validation', title: tf('contextmenu.validation') },
-  { key: 'divider' },
-  { key: 'cell-printable', title: tf('contextmenu.cellprintable') },
-  { key: 'cell-non-printable', title: tf('contextmenu.cellnonprintable') },
-  { key: 'divider' },
-  { key: 'cell-editable', title: tf('contextmenu.celleditable') },
-  { key: 'cell-non-editable', title: tf('contextmenu.cellnoneditable') },
+  { key: 'divider', feature: 'Insert' },
+  { key: 'insert-row', title: tf('contextmenu.insertRow'), feature: 'Insert' },
+  { key: 'insert-column', title: tf('contextmenu.insertColumn'), feature: 'Insert' },
+  { key: 'divider', feature: 'Delete' },
+  { key: 'delete-row', title: tf('contextmenu.deleteRow'), feature: 'Delete' },
+  { key: 'delete-column', title: tf('contextmenu.deleteColumn'), feature: 'Delete' },
+  { key: 'delete-cell-text', title: tf('contextmenu.deleteCellText'), feature: 'Delete' },
+  { key: 'hide', title: tf('contextmenu.hide'), feature: 'Hide' },
+  { key: 'divider', feature: 'Validation' },
+  { key: 'validation', title: tf('contextmenu.validation'), feature: 'Validation' },
+  { key: 'divider', feature: 'CellPrintable' },
+  { key: 'cell-printable', title: tf('contextmenu.cellprintable'), feature: 'CellPrintable' },
+  { key: 'cell-non-printable', title: tf('contextmenu.cellnonprintable'), feature: 'CellPrintable' },
+  { key: 'divider', feature: 'CellEditable' },
+  { key: 'cell-editable', title: tf('contextmenu.celleditable'), feature: 'CellEditable' },
+  { key: 'cell-non-editable', title: tf('contextmenu.cellnoneditable'), feature: 'CellEditable' },
 ];
 
 function buildMenuItem(item) {
   if (item.key === 'divider') {
     return h('div', `${cssPrefix}-item divider`);
   }
-  return h('div', `${cssPrefix}-item`)
+  const el = h('div', `${cssPrefix}-item`)
     .on('click', () => {
       this.itemClick(item.key);
       this.hide();
@@ -40,14 +40,22 @@ function buildMenuItem(item) {
       item.title(),
       h('div', 'label').child(item.label || ''),
     );
+  if (item.key === 'hide') {
+    this.hideEl = el;
+  }
+  return el;
 }
 
 function buildMenu() {
-  return menuItems.map(it => buildMenuItem.call(this, it));
+  return menuItems
+    .filter(it => !(it.feature && !this.data.settings.features[it.feature]))
+    .map(it => buildMenuItem.call(this, it));
 }
 
 export default class ContextMenu {
-  constructor(viewFn, isHide = false) {
+  constructor(data, viewFn, isHide = false) {
+    this.data = data;
+    this.hideEl = null;
     this.menuItems = buildMenu.call(this);
     this.el = h('div', `${cssPrefix}-contextmenu`)
       .children(...this.menuItems)
@@ -61,11 +69,12 @@ export default class ContextMenu {
   // row-col: the whole rows or the whole cols
   // range: select range
   setMode(mode) {
-    const hideEl = this.menuItems[12];
-    if (mode === 'row-col') {
-      hideEl.show();
-    } else {
-      hideEl.hide();
+    if (this.hideEl) {
+      if (mode === 'row-col') {
+        this.hideEl.show();
+      } else {
+        this.hideEl.hide();
+      }
     }
   }
 

--- a/src/component/sheet.js
+++ b/src/component/sheet.js
@@ -873,7 +873,7 @@ export default class Sheet {
     // data validation
     this.modalValidation = new ModalValidation();
     // contextMenu
-    this.contextMenu = new ContextMenu(() => this.getRect(), !showContextmenu);
+    this.contextMenu = new ContextMenu(data, () => this.getRect(), !showContextmenu);
     // selector
     this.selector = new Selector(data);
     this.overlayerCEl = h('div', `${cssPrefix}-overlayer-content`)

--- a/src/component/toolbar/index.js
+++ b/src/component/toolbar/index.js
@@ -27,6 +27,7 @@ import More from './more';
 import { h } from '../element';
 import { cssPrefix } from '../../config';
 import { bind } from '../event';
+import { Features } from '../../core/features';
 
 function buildDivider() {
   return h('div', `${cssPrefix}-toolbar-divider`);
@@ -87,51 +88,60 @@ export default class Toolbar {
     this.widthFn = widthFn;
     this.isHide = isHide;
     const style = data.defaultStyle();
-    this.items = [
+    var allItems = [
       [
-        this.undoEl = new Undo(),
-        this.redoEl = new Redo(),
-        new Print(),
-        this.paintformatEl = new Paintformat(),
-        this.clearformatEl = new Clearformat(),
+        [this.undoEl = new Undo(), 'Undo'],
+        [this.redoEl = new Redo(), 'Redo'],
+        [new Print(), 'Print'],
+        [this.paintformatEl = new Paintformat(), 'PaintFormat'],
+        [this.clearformatEl = new Clearformat(), 'ClearFormat'],
       ],
-      buildDivider(),
       [
-        this.formatEl = new Format(),
+        [this.formatEl = new Format(), 'Format'],
       ],
-      buildDivider(),
       [
-        this.fontEl = new Font(),
-        this.fontSizeEl = new FontSize(),
+        [this.fontEl = new Font(), 'Font'],
+        [this.fontSizeEl = new FontSize(), 'FontSize'],
       ],
-      buildDivider(),
       [
-        this.boldEl = new Bold(),
-        this.italicEl = new Italic(),
-        this.underlineEl = new Underline(),
-        this.strikeEl = new Strike(),
-        this.textColorEl = new TextColor(style.color),
+        [this.boldEl = new Bold(), 'Bold'],
+        [this.italicEl = new Italic(), 'Italic'],
+        [this.underlineEl = new Underline(), 'Underline'],
+        [this.strikeEl = new Strike(), 'Strike'],
+        [this.textColorEl = new TextColor(style.color), 'TextColor'],
       ],
-      buildDivider(),
       [
-        this.fillColorEl = new FillColor(style.bgcolor),
-        this.borderEl = new Border(),
-        this.mergeEl = new Merge(),
+        [this.fillColorEl = new FillColor(style.bgcolor), 'FillColor'],
+        [this.borderEl = new Border(), 'Border'],
+        [this.mergeEl = new Merge(), 'Merge'],
       ],
-      buildDivider(),
       [
-        this.alignEl = new Align(style.align),
-        this.valignEl = new Valign(style.valign),
-        this.textwrapEl = new Textwrap(),
+        [this.alignEl = new Align(style.align), 'Align'],
+        [this.valignEl = new Valign(style.valign), 'VAlign'],
+        [this.textwrapEl = new Textwrap(), 'TextWrap'],
       ],
-      buildDivider(),
       [
-        this.freezeEl = new Freeze(),
-        this.autofilterEl = new Autofilter(),
-        this.formulaEl = new Formula(),
-        this.moreEl = new More(),
+        [this.freezeEl = new Freeze(), 'Freeze'],
+        [this.autofilterEl = new Autofilter(), 'AutoFilter'],
+        [this.formulaEl = new Formula(), 'Formula'],
+        [this.moreEl = new More(), 'More'],
       ],
     ];
+    this.items = [];
+    allItems.forEach((it) => {
+      var tmp = [];
+      it.forEach((item) => {
+        if (this.data.settings.features[item[1]]) {
+          tmp.push(item[0]);
+        };
+      });
+      if (tmp.length) {
+        if (this.items.length) {
+          this.items.push(buildDivider());
+        };
+        this.items.push(tmp);
+      };
+    });
 
     this.el = h('div', `${cssPrefix}-toolbar`);
     this.btns = h('div', `${cssPrefix}-toolbar-btns`);

--- a/src/core/data_proxy.js
+++ b/src/core/data_proxy.js
@@ -13,6 +13,7 @@ import { Validations } from './validation';
 import { CellRange } from './cell_range';
 import { expr2xy, xy2expr } from './alphabet';
 import { t } from '../locale/locale';
+import { FeaturesAll } from './features';
 
 // private methods
 /*
@@ -76,6 +77,7 @@ const defaultSettings = {
   },
   showGrid: true,
   showToolbar: true,
+  features: FeaturesAll,
   showContextmenu: true,
   row: {
     len: 100,

--- a/src/core/features.js
+++ b/src/core/features.js
@@ -1,0 +1,39 @@
+export var FeaturesAll = {
+  Undo: true,
+  Redo: true,
+  Print: true,
+  PaintFormat: true,
+  ClearFormat: true,
+
+  Format: true,
+
+  Font: true,
+  FontSize: true,
+
+  Bold: true,
+  Italic: true,
+  Underline: true,
+  Strike: true,
+  TextColor: true,
+
+  FillColor: true,
+  Border: true,
+  Merge: true,
+
+  Align: true,
+  VAlign: true,
+  TextWrap: true,
+
+  Freeze: true,
+  AutoFilter: true,
+  Formula: true,
+  More: true,
+
+  CellEditable: true,
+  CellPrintable: true,
+  Validation: true,
+  Delete: true,
+  Insert: true,
+  Hide: true,
+};
+

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import Bottombar from './component/bottombar';
 import { cssPrefix } from './config';
 import { locale } from './locale/locale';
 import './index.less';
+import { FeaturesAll } from './core/features';
 
 
 class Spreadsheet {
@@ -122,6 +123,7 @@ const spreadsheet = (el, options = {}) => new Spreadsheet(el, options);
 if (window) {
   window.x_spreadsheet = spreadsheet;
   window.x_spreadsheet.locale = (lang, message) => locale(lang, message);
+  window.x_spreadsheet.FeaturesAll = FeaturesAll;
 }
 
 export default Spreadsheet;


### PR DESCRIPTION
I was missing the ability to customize the spreadsheet, so I added a new setting variable called "features" to selectively enable/disable features. These include toolbar icons and elements in the context menu.

Per default, every feature is enabled. You can just list the features you want, or disable some of them. If we e.g. want to disable Bold, Redo and Italic, we can do the following:

```
var xs = x_spreadsheet(
  '#x-spreadsheet-demo', 
  {
    showToolbar: true, 
    showGrid: true, 
    features: {...x_spreadsheet.FeaturesAll, Bold: false, Redo: false, Italic: false},
  }
)
```

All available features are listed in [/src/core/features.js](https://github.com/kilroy42/x-spreadsheet/blob/master/src/core/features.js)
