### PR TITLE
解决在sheet宽度超出容器需要滑动时，触发浏览器后退或前进功能的bug

### DIFF
--- a/src/component/sheet.js
+++ b/src/component/sheet.js
@@ -603,6 +603,9 @@ function sheetInitEvents() {
         overlayerMousedown.call(this, evt);
       }
     })
+    .on('mousewheel', (evt) => {
+      evt.preventDefault();
+    })
     .on('mousewheel.stop', (evt) => {
       overlayerMousescroll.call(this, evt);
     })


### PR DESCRIPTION
当sheet内col的列数需要滑动才能查看时，使用mac等触摸滑动时会触发浏览器的后退或前进，导致无法正常滑动sheet。