### PR TITLE
fix: cells around the fixed column/row are not rendered when zooming out in browser

### DIFF
--- a/src/component/table.js
+++ b/src/component/table.js
@@ -268,7 +268,7 @@ function renderContentGrid({
   // const sumWidth = cols.sumWidth(sci, eci + 1);
   // const sumHeight = rows.sumHeight(sri, eri + 1);
   // console.log('sumWidth:', sumWidth);
-  draw.clearRect(0, 0, w, h);
+  // draw.clearRect(0, 0, w, h);
   if (!settings.showGrid) {
     draw.restore();
     return;


### PR DESCRIPTION
### Steps to Reproduce
1. Set fixed column/row.
2. Set browser zoom level lower than 50%.

[**Zoom level 50%**]
<img width="391" alt="Screen Shot 2021-04-02 at 1 21 09" src="https://user-images.githubusercontent.com/46554918/113327238-aa15f100-9355-11eb-97a7-608ac66e6b7d.png">

[**Zoom level 33%**]
<img width="265" alt="Screen Shot 2021-04-02 at 1 21 18" src="https://user-images.githubusercontent.com/46554918/113327341-cf0a6400-9355-11eb-877c-6bbf358c6aa7.png">

### Possible solution
I found that commenting out the following line resolves this issue.
https://github.com/myliang/x-spreadsheet/blob/master/src/component/table.js#L271

I confirmed that replacing the above code to the following one fixes this issue.

[**Zoom level 33%**]: (After applying this PR)
<img width="258" alt="Screen Shot 2021-04-02 at 1 22 13" src="https://user-images.githubusercontent.com/46554918/113328761-b3a05880-9357-11eb-8b87-aa876f6a5963.png">
