### PR TITLE
Fix table edit history

### DIFF
--- a/src/core/data_proxy.js
+++ b/src/core/data_proxy.js
@@ -347,6 +347,8 @@ export default class DataProxy {
     this.exceptRowSet = new Set();
     this.sortedRowMap = new Map();
     this.unsortedRowMap = new Map();
+    this.currentEditRowIdx = null;
+    this.currentEditColIdx = null;
   }
 
   addValidation(mode, ref, validator) {
@@ -964,14 +966,30 @@ export default class DataProxy {
     return this.getCellStyleOrDefault(ri, ci);
   }
 
+  isStartEditing(rowIdx, colIdx) {
+    if (this.currentEditRowIdx === null && this.currentEditColIdx === null) {
+      this.currentEditRowIdx = rowIdx;
+      this.currentEditColIdx = colIdx;
+      return true;
+    }
+    return false;
+  }
+
+  stopEditing() {
+    this.currentEditRowIdx = null;
+    this.currentEditColIdx = null;
+  }
+
   // state: input | finished
   setCellText(ri, ci, text, state) {
     const { rows, history, validations } = this;
     if (state === 'finished') {
-      rows.setCellText(ri, ci, '');
-      history.add(this.getData());
       rows.setCellText(ri, ci, text);
+      this.stopEditing();
     } else {
+      if (this.isStartEditing(ri, ci)) {
+        history.add(this.getData());
+      }
       rows.setCellText(ri, ci, text);
       this.change(this.getData());
     }


### PR DESCRIPTION
Save the correct table state to the history upon edit. Whenever an edit to a
cell is begun, the pre-edit state is now saved to the history so that a
restore is possible (via undo button).