### PR TITLE
fix: typeof instead of instanceof to check for object

### DIFF
--- a/src/core/helper.js
+++ b/src/core/helper.js
@@ -37,7 +37,7 @@ function equals(obj1, obj2) {
       for (let ai = 0; ai < v1.length; ai += 1) {
         if (!equals(v1[ai], v2[ai])) return false;
       }
-    } else if (typeof v1 !== 'function' && !Array.isArray(v1) && v1 instanceof Object) {
+    } else if (typeof v1 !== 'function' && !Array.isArray(v1) && typeof v1 === 'object' && v1 !== null) {
       if (!equals(v1, v2)) return false;
     }
   }


### PR DESCRIPTION
Hello,
I had an issue with some of the toolbar button (bold/italic) that were not working.
I think it had to do with the way I loadData(), but could not figure out what's wrong exactly.

Here's the issue from devtool (it is a style.font) : 
![Screenshot from 2021-06-22 10-22-25](https://user-images.githubusercontent.com/86291345/122895612-91abe600-d348-11eb-859b-f23ffd0b31ea.png)

This would make the  `helper.equals` returns truthy instead of falsy which skip the creation of a new style (thus reuse an existing one).


