### PR TITLE
feat: autofocus setting added

### DIFF
--- a/src/component/selector.js
+++ b/src/component/selector.js
@@ -6,8 +6,9 @@ const selectorHeightBorderWidth = 2 * 2 - 1;
 let startZIndex = 10;
 
 class SelectorElement {
-  constructor(useHideInput = false) {
+  constructor(useHideInput = false, autoFocus = true) {
     this.useHideInput = useHideInput;
+    this.autoFocus = autoFocus;
     this.inputChange = () => {};
     this.cornerEl = h('div', `${cssPrefix}-selector-corner`);
     this.areaEl = h('div', `${cssPrefix}-selector-area`)
@@ -52,7 +53,11 @@ class SelectorElement {
     this.areaEl.offset(of).show();
     if (this.useHideInput) {
       this.hideInputDiv.offset(of);
-      this.hideInput.val('').focus();
+      if (this.autoFocus) {
+        this.hideInput.val('').focus();
+      } else {
+        this.hideInput.val('');
+      }
     }
   }
 
@@ -195,9 +200,10 @@ function setAllClipboardOffset(offset) {
 
 export default class Selector {
   constructor(data) {
+    const { autoFocus } = data.settings;
     this.inputChange = () => {};
     this.data = data;
-    this.br = new SelectorElement(true);
+    this.br = new SelectorElement(true, autoFocus);
     this.t = new SelectorElement();
     this.l = new SelectorElement();
     this.tl = new SelectorElement();

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,6 +15,7 @@ declare module 'x-data-spreadsheet' {
       left?: ExtendToolbarOption[],
       right?: ExtendToolbarOption[],
     };
+    autoFocus?: boolean;
     view?: {
       height: () => number;
       width: () => number;


### PR DESCRIPTION
I'm using x-spreadsheet at the bottom of the page that contains a lot of HTML code.
When I open this page I see that the screen immediately scrolls to the spreadsheet at the bottom.
So I need to scroll back to the top of the page to read the content and this is frustrating.
That's why I added the setting `autoFocus` to switch this behavior off.