### PR TITLE
fix: Disable editing bug

### DIFF
--- a/src/component/editor.js
+++ b/src/component/editor.js
@@ -81,7 +81,7 @@ function inputEventHandler(evt) {
       resetTextareaSize.call(this);
       this.change('input', v);
     } else {
-      evt.target.value = cell.text;
+      evt.target.value = cell.text || '';
     }
   } else {
     this.inputText = v;


### PR DESCRIPTION
When a cell with no value is set to be non editable, undefind appears when editing again