### PR TITLE
expose 'scrollbarMove' method from Sheet class

### DIFF
--- a/src/component/sheet.js
+++ b/src/component/sheet.js
@@ -1010,4 +1010,8 @@ export default class Sheet {
       top: rows.height,
     };
   }
+
+  autoScroll() {
+    scrollbarMove.call(this);
+  }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,7 +39,7 @@ declare module 'x-data-spreadsheet' {
       underline: boolean;
       color: string;
       font: {
-        name: 'Helvetica';
+        name: 'Helvetica' | string;
         size: number;
         bold: boolean;
         italic: false;


### PR DESCRIPTION
This exposes `scrollbarMove` function from `Sheet` class so it can be used outside the library to move the scrollbar while user mouse-dragging to select cells outside the viewport. 